### PR TITLE
Extend functionality to allow for `onlyPrefix` and `exceptPrefix`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+max_line_length = 100
+tab_width = 2
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+max_line_length = off
+
+[COMMIT_EDITMSG]
+max_line_length = off

--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,11 @@ typings/
 .DS_Store
 Thumbs.db
 
+# IDE metadata
+.idea/
+.vs/
+.vscode/
+
 # Ignore built ts files
 __tests__/runner/*
 lib/**/*

--- a/README.md
+++ b/README.md
@@ -36,6 +36,26 @@ jobs:
           expire-in: 7days # Setting this to 0 will delete all artifacts
 ```
 
+### Optional arguments
+
+#### `onlyPrefix`
+
+Only purge artifacts that start with `tmp_` as a prefix.
+
+```yaml
+with:
+  onlyPrefix: tmp_  
+```
+
+#### `exceptPrefix`
+
+Exclude any artifacts that start with `prod_` as a prefix
+
+```yaml
+with:
+  exceptPrefix: prod_
+```
+
 ## Contributing
 
 There are few improvements to be made, namely

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -34,4 +34,76 @@ describe('shouldDelete', () => {
     }
     expect(shouldDelete(expiredArtifact as any, actionInptus)).toEqual(true)
   })
+  test('should delete when matched by onlyPrefix', () => {
+    const expiredArtifact = {
+      created_at: new Date(),
+      name: 'tmp_artifact.test'
+    }
+    const actionInptus: IActionInputs = {
+      expireInMs: 0,
+      onlyPrefix: 'tmp',
+      exceptPrefix: ''
+    }
+    expect(shouldDelete(expiredArtifact as any, actionInptus)).toEqual(true)
+  })
+  test('should not delete when not matched by onlyPrefix', () => {
+    const expiredArtifact = {
+      created_at: new Date(),
+      name: 'build_artifact.test'
+    }
+    const actionInptus: IActionInputs = {
+      expireInMs: 0,
+      onlyPrefix: 'tmp',
+      exceptPrefix: ''
+    }
+    expect(shouldDelete(expiredArtifact as any, actionInptus)).toEqual(false)
+  })
+  test('should delete when not matched by exceptPrefix', () => {
+    const expiredArtifact = {
+      created_at: new Date(),
+      name: 'tmp_artifact.test'
+    }
+    const actionInptus: IActionInputs = {
+      expireInMs: 0,
+      onlyPrefix: '',
+      exceptPrefix: 'master_'
+    }
+    expect(shouldDelete(expiredArtifact as any, actionInptus)).toEqual(true)
+  })
+  test('should not delete when matched by exceptPrefix', () => {
+    const expiredArtifact = {
+      created_at: new Date(),
+      name: 'master_artifact.test'
+    }
+    const actionInptus: IActionInputs = {
+      expireInMs: 0,
+      onlyPrefix: '',
+      exceptPrefix: 'master_'
+    }
+    expect(shouldDelete(expiredArtifact as any, actionInptus)).toEqual(false)
+  })
+  test('should not delete when matched by both onlyPrefix and exceptPrefix', () => {
+    const expiredArtifact = {
+      created_at: new Date(),
+      name: 'master_tmp_artifact.test'
+    }
+    const actionInptus: IActionInputs = {
+      expireInMs: 0,
+      onlyPrefix: 'master_',
+      exceptPrefix: 'master_tmp_'
+    }
+    expect(shouldDelete(expiredArtifact as any, actionInptus)).toEqual(false)
+  })
+  test('should delete when matched by onlyPrefix but not exceptPrefix', () => {
+    const expiredArtifact = {
+      created_at: new Date(),
+      name: 'master_tmp_artifact.test'
+    }
+    const actionInptus: IActionInputs = {
+      expireInMs: 0,
+      onlyPrefix: 'master_',
+      exceptPrefix: 'tmp_'
+    }
+    expect(shouldDelete(expiredArtifact as any, actionInptus)).toEqual(true)
+  })
 })

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -7,19 +7,31 @@ describe('shouldDelete', () => {
     const days = 2
     const expireInMs = days * 86400000
     const expiredArtifact = { created_at: sub(new Date(), { days }) }
-    const actionInptus: IActionInputs = { expireInMs }
+    const actionInptus: IActionInputs = {
+      expireInMs,
+      onlyPrefix: '',
+      exceptPrefix: ''
+    }
     expect(shouldDelete(expiredArtifact as any, actionInptus)).toEqual(true)
   })
   test('not expired', () => {
     const days = 2
     const expireInMs = (days + 1) * 86400000
     const expiredArtifact = { created_at: sub(new Date(), { days }) }
-    const actionInptus: IActionInputs = { expireInMs }
+    const actionInptus: IActionInputs = {
+      expireInMs,
+      onlyPrefix: '',
+      exceptPrefix: ''
+    }
     expect(shouldDelete(expiredArtifact as any, actionInptus)).toEqual(false)
   })
   test('expired when expireInDays is zero', () => {
     const expiredArtifact = { created_at: new Date() }
-    const actionInptus: IActionInputs = { expireInMs: 0 }
+    const actionInptus: IActionInputs = {
+      expireInMs: 0,
+      onlyPrefix: '',
+      exceptPrefix: ''
+    }
     expect(shouldDelete(expiredArtifact as any, actionInptus)).toEqual(true)
   })
 })

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,14 @@ inputs:
   token:
     required: true
     description: 'Github auth token'
+  onlyPrefix:
+    required: false
+    description: 'Only artifacts with the specified prefix will be deleted'
+    default: ''
+  exceptPrefix:
+    required: false
+    description: 'Artifacts with this prefix will not be included for deletion'
+    default: ''
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,10 +12,15 @@ export function shouldDelete(
   artifact: ActionsListArtifactsForRepoResponseArtifactsItem,
   actionInputs: IActionInputs
 ): boolean {
+  const { expireInMs, onlyPrefix, exceptPrefix } = actionInputs
+
+  const included = artifact.name.startsWith(onlyPrefix)
+  const excluded = exceptPrefix && artifact.name.startsWith(exceptPrefix)
   const expired =
     differenceInMilliseconds(new Date(), new Date(artifact.created_at)) >=
-    actionInputs.expireInMs
-  return expired
+    expireInMs
+
+  return included && !excluded && expired
 }
 
 export async function main(): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ export function shouldDelete(
 ): boolean {
   const { expireInMs, onlyPrefix, exceptPrefix } = actionInputs
 
-  const included = artifact.name.startsWith(onlyPrefix)
+  const included = onlyPrefix === '' || artifact.name.startsWith(onlyPrefix)
   const excluded = exceptPrefix && artifact.name.startsWith(exceptPrefix)
   const expired =
     differenceInMilliseconds(new Date(), new Date(artifact.created_at)) >=

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -44,9 +44,14 @@ export async function* eachArtifact(
 
 export interface IActionInputs {
   expireInMs: number
+  onlyPrefix: string
+  exceptPrefix: string
 }
 export function getActionInputs(): IActionInputs {
   const expireInHumanReadable = core.getInput('expire-in', { required: true })
   const expireInMs = parseDuration(expireInHumanReadable)
-  return { expireInMs }
+  const onlyPrefix = core.getInput('onlyPrefix', { required: false })
+  const exceptPrefix = core.getInput('exceptPrefix', { required: false })
+
+  return { expireInMs, onlyPrefix, exceptPrefix }
 }


### PR DESCRIPTION
Hi @kolpav, thanks a lot for making this action.

Are you accepting PRs?

Here are my suggested changes:

- Add editorconfig that align with the code as it is now for cross-editor support.
- Ignore IDE specific folders.
- Add `onlyPrefix` which checks if the name of the artifact matches it to include for deletion.
- Add `exceptPrefix` which excludes a certain prefix from being deleted.
- Add a bunch of test cases for the different possible scenarios.

Given that [artifacts do not have many handles](https://developer.github.com/v3/actions/artifacts/#response) I decided to use the name of the artifact.